### PR TITLE
Coroutine changes and some comments 

### DIFF
--- a/DeltaVTest.cs
+++ b/DeltaVTest.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 using PreFlightTests;
 
@@ -11,14 +8,24 @@ namespace StockishDeltaV
     {           
         public override string GetConcernDescription()
         {
-            if (EditorLogic.fetch.ship.vesselDeltaV == null) return "";
-            return "Atmosphere: " + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVASL,0) + "m/s"+Environment.NewLine+ "Vacuum DeltaV:" + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVVac,0)+"m/s";
+            //FIXME: This has the problem that when the ship gets changed, the sim needs some ticks to run again.
+            //Maybe start some kind of delayed info in GameEvents.onEditorPartPlaced
+            if (EditorLogic.fetch.ship.vesselDeltaV == null || !EditorLogic.fetch.ship.vesselDeltaV.isReady)
+            {
+                return "DeltaV not ready"; //FIXME: This never occurs?
+            }
+            return "Atmosphere: " + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVASL, 0) + "m/s" + Environment.NewLine + "Vacuum DeltaV:" + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVVac, 0) + "m/s";
         }
 
         public override string GetConcernTitle()
         {
-            if (EditorLogic.fetch.ship.vesselDeltaV == null) return "Delta V: Not Ready";
-            return "Delta V: " + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVVac,0)+"m/s";
+            //FIXME: This has the problem that when the ship gets changed, the sim needs some ticks to run again.
+            //Maybe start some kind of delayed info in GameEvents.onEditorPartPlaced
+            if (EditorLogic.fetch.ship.vesselDeltaV == null || !EditorLogic.fetch.ship.vesselDeltaV.isReady)
+            {
+                return "DeltaV not ready";  //FIXME: This never occurs?
+            }
+            return "Delta V: " + Math.Round(EditorLogic.fetch.ship.vesselDeltaV.totalDeltaVVac, 0) + "m/s";
         }
 
         public override DesignConcernSeverity GetSeverity()
@@ -28,9 +35,7 @@ namespace StockishDeltaV
 
         public override bool TestCondition()
         {
-            bool condition = EditorLogic.fetch.ship.vesselDeltaV == null;
-            Debug.Log("[StockishDeltaV] condition = " + condition);
-            return condition;
+            return false;
         }
     }
 }

--- a/StockishDeltaV.cs
+++ b/StockishDeltaV.cs
@@ -1,53 +1,68 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using KSP.UI.Screens;
+﻿﻿using KSP.UI.Screens;
 using UnityEngine;
-using PreFlightTests;
+using System.Collections;
+using UnityEngine.Collections;
 
 namespace StockishDeltaV
 {
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     public class StockishDeltaV : MonoBehaviour
     {
-        public static StockishDeltaV instance;
-        DeltaVTest test;
+        public static StockishDeltaV _instance;
+        private DeltaVTest _test;
 
         void Awake()
         {
-            if (instance != null) Destroy(this);
-            else instance = this;
-            GameEvents.onGUIEngineersReportReady.Add(ReportReady);
-            GameEvents.onGUIEngineersReportDestroy.Add(ReportDestroyed);
+            //Actually a overridden check for UnityNull, meaning the instance could actually be destroyed
+            //e.g. destroyed by KSP, and we're instantiating a fresh one in the same tick from some other source.
+            //Checking != null would only ensure it's NOT destroyed, but we instead need to make sure it's either null or destroyed (UnityNull)
+            if (_instance == null) 
+            {
+                _instance = this;   
+
+                //If for some reason this object gets destroyed
+                GameEvents.onGUIEngineersReportReady.Add(ReportReady);
+                GameEvents.onGUIEngineersReportDestroy.Add(ReportDestroyed);
+            }
+            else
+            {
+                Destroy(this);
+            }
         }
 
-        private void AddTest()
-        {
-            if(EditorLogic.fetch.ship.vesselDeltaV == null)
+        private IEnumerator AddTest()
+        {            
+            //Wait for DeltaV simulation to be instantiated and to finish.
+            while (EditorLogic.fetch.ship.vesselDeltaV == null || !EditorLogic.fetch.ship.vesselDeltaV.isReady)
             {
-                Invoke("AddTest", 0.5f);
-                return;
+                yield return new WaitForSeconds(0.5f);
             }
-            if(!EditorLogic.fetch.ship.vesselDeltaV.isReady)
-            {
-                Invoke("AddTest", 0.5f);
-                return;
-            }
-            test = new DeltaVTest();
-            EngineersReport.Instance.AddTest(test);
+
+            //Register our test in the Report
+            _test = new DeltaVTest();
+            EngineersReport.Instance.AddTest(_test);
+            EngineersReport.Instance.ShouldTest(_test);
         }
+
+        private void RemoveTest()
+        {
+            //In case we're waiting for the DeltaV, stop waiting
+            StopAllCoroutines();
+
+            //Only if it was actually added, deregister it.
+            if (_test != null) EngineersReport.Instance.RemoveTest(_test);
+        }
+
         private void ReportDestroyed()
         {
-            if(test != null) EngineersReport.Instance.RemoveTest(test);
+            RemoveTest();
         }
 
         private void ReportReady()
         {
             Debug.Log("[StockishDeltaV] ReportReady");
-            if (test != null) EngineersReport.Instance.RemoveTest(test);
-            AddTest();
-        }
-
+            RemoveTest();
+            StartCoroutine(AddTest());
+        }   
     }
 }

--- a/StockishDeltaV.sln
+++ b/StockishDeltaV.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StockishDeltaV", "StockishDeltaV.csproj", "{ECAE5929-0421-47A7-9DF6-DFD112BEC127}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ECAE5929-0421-47A7-9DF6-DFD112BEC127}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECAE5929-0421-47A7-9DF6-DFD112BEC127}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECAE5929-0421-47A7-9DF6-DFD112BEC127}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECAE5929-0421-47A7-9DF6-DFD112BEC127}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6C6184B0-84C9-4010-AC9C-D895E2756AD8}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
The problem with VesselDeltaV is its asynchronous calculation; whereas the engineering report is mostly synchronous.

That means you will miss  one update every time. Easiest repro: Put a flea on a Capsule, see the dV, remove Flea, dV stays the same (because this time, there is no coroutine waiting... doesn't work when the report is already open, btw), and place the Flea again, see dV of 0, remove the flea again, see original (wrong) dV.